### PR TITLE
Drop babel/bluebird

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-    "presets": ["latest"],
-    "plugins": "transform-runtime"
-}

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "main": "src/eee.js",
   "repository": "Darkhogg/enhanced-event-emitter",
   "scripts": {
-    "test": "npm run babel && true"
+
   },
   "dependencies": {
-    "bluebird": "^3.4.6"
+
   }
 }

--- a/src/eee.js
+++ b/src/eee.js
@@ -1,6 +1,3 @@
-const Promise = require('bluebird');
-
-
 const PRIORITY = Object.freeze({
     'HIGHEST': -1000,
     'HIGHER':   -100,
@@ -129,7 +126,7 @@ class Emitter {
         const names = Array.isArray(names_) ? names_ : [names_];
         const $res = new Result();
 
-        await Promise.delay(); // yield the current event for fully async emits
+        await 1; // yield the current event for fully async emits (await is always async)
 
         const listeners = [];
 
@@ -151,7 +148,7 @@ class Emitter {
             const $evt = new Event();
 
             $evt._active = true;
-            const res = await Promise.cast(listener.hook.call(listener.thisArg, $evt, ...args));
+            const res = await listener.hook.call(listener.thisArg, $evt, ...args);
             $evt._active = false;
 
             $evt._value = res;

--- a/src/eee.js
+++ b/src/eee.js
@@ -126,7 +126,7 @@ class Emitter {
         const names = Array.isArray(names_) ? names_ : [names_];
         const $res = new Result();
 
-        await 1; // yield the current event for fully async emits (await is always async)
+        await Promise.resolve(); // yield the current event for fully async emits (await is always async)
 
         const listeners = [];
 


### PR DESCRIPTION
Scrapped babel as pretty much everything should support native promises now.

* scrapped bluebird, no need for casting or delay function due to await semantics
    * https://github.com/tc39/ecmascript-asyncawait/issues/33#issuecomment-127426745

* I realise not everything supports async await, in which case I'll put babel back with local config instead of global config, I would just need to know that the supported browser versions and node versions are.